### PR TITLE
Issue 503: Smoother login via reminder email links

### DIFF
--- a/html/modules/custom/bc_dc/src/Service/ReviewReminder.php
+++ b/html/modules/custom/bc_dc/src/Service/ReviewReminder.php
@@ -147,7 +147,8 @@ class ReviewReminder implements ContainerInjectionInterface {
             'query' => ['destination' => $update['dataset_url']],
             'absolute' => TRUE,
           ]);
-          $body[] = $update['title'] . "\n" . $update['dataset_url'];
+          // GC Notify requires Markdown formatting, not HTML.
+          $body[] = sprintf('* [%s](%s)', $update['title'], $url_via_login->toString());
         }
       }
     }

--- a/html/modules/custom/bc_dc/src/Service/ReviewReminder.php
+++ b/html/modules/custom/bc_dc/src/Service/ReviewReminder.php
@@ -80,20 +80,16 @@ class ReviewReminder implements ContainerInjectionInterface {
   public function sendRemindersToOneUser(int $uid, array $notifications): ?bool {
     $account = $this->entityTypeManager->getStorage('user')->load($uid);
     $email = $account?->getEmail();
+    $logger = $this->getLogger('bc_dc');
+
     if (!$email) {
-      $context = [
-        '@uid' => $uid,
-      ];
-      $this->getLogger('bc_dc')->error('ReviewReminder: User @uid has no email address.', $context);
+      $logger->error('ReviewReminder: User @uid has no email address.', ['@uid' => $uid]);
       return NULL;
     }
 
     $body = $this->generateBody($notifications);
     if (!$body) {
-      $context = [
-        '@uid' => $uid,
-      ];
-      $this->getLogger('bc_dc')->error('ReviewReminder: Empty message for user @uid.', $context);
+      $logger->error('ReviewReminder: Empty message for user @uid.', ['@uid' => $uid]);
       return NULL;
     }
 
@@ -101,16 +97,10 @@ class ReviewReminder implements ContainerInjectionInterface {
 
     $success = GcNotifyApiService::sendMessage([$email], $subject, $body);
     if ($success) {
-      $context = [
-        '@uid' => $uid,
-      ];
-      $this->getLogger('bc_dc')->notice('Sent ReviewReminder message to user @uid.', $context);
+      $logger->notice('Sent ReviewReminder message to user @uid.', ['@uid' => $uid]);
     }
     else {
-      $context = [
-        '@uid' => $uid,
-      ];
-      $this->getLogger('bc_dc')->error('Failed to send ReviewReminder message to user @uid.', $context);
+      $logger->error('Failed to send ReviewReminder message to user @uid.', ['@uid' => $uid]);
     }
 
     return $success;

--- a/html/modules/custom/bc_dc/src/Service/ReviewReminder.php
+++ b/html/modules/custom/bc_dc/src/Service/ReviewReminder.php
@@ -129,12 +129,12 @@ class ReviewReminder implements ContainerInjectionInterface {
         $body[] = $update_message . ':';
         foreach ($notifications[$update_type] as $update) {
           // If a user clicks one of these links to one of
-          // their Metadata Recordsin the email they receive,
+          // their Metadata Records in the email they receive,
           // they will confusingly get a "Not Found" error if they are not logged in.
           // So we make the link to instead to the login page, with a REDIRECT
           // to the real URL we want to take them to.
           $url_via_login = Url::fromRoute('user.login', [], [
-            'query' => ['destination' => $update['dataset_url']],
+            'query' => ['destination' => '/node/' . $update['dataset_nid']],
             'absolute' => TRUE,
           ]);
           // GC Notify requires Markdown formatting, not HTML.
@@ -187,7 +187,7 @@ class ReviewReminder implements ContainerInjectionInterface {
       if ($review_status) {
         $reminders[$data_set->getOwnerId()][$review_status][] = [
           'title' => $data_set->getTitle(),
-          'dataset_url' => $data_set->toUrl('canonical', ['absolute' => FALSE])->toString(),
+          'dataset_nid' => $data_set_nid,
         ];
       }
     }


### PR DESCRIPTION
- Only show the Title of the MR that needs updating, hiding the URL inside the hyperlink
- Have the link go to the login page, with a redirect to the MR edit page. e.g. https://cat.data.fin.gov.bc.ca/user/login?destination=/node/188